### PR TITLE
Added overflow auto to body

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  overflow: auto !important;
 }
 
 code {


### PR DESCRIPTION
Without specifically setting auto for the entire page, scroll was disappearing because "overflow: hidden" was being applied to the page on child component renders for some reason, which made the scroll bar disappear.