### PR TITLE
Set default auction date to one day after current

### DIFF
--- a/src/components/createEditGameStep2.js
+++ b/src/components/createEditGameStep2.js
@@ -57,7 +57,7 @@ class CreateEditGameStep2 extends Component {
             type='datetime-local'
             min={moment().add(1, 'days').format('YYYY-MM-DDTHH:mm')}
             max={moment(this.props.startDate).format('YYYY-MM-DDTHH:mm')}
-            value={moment(this.props.auctionDate).isValid() ?  moment(this.props.auctionDate).format('YYYY-MM-DDTHH:mm') : moment().add(7, 'days').format('YYYY-MM-DDTHH:mm')}
+            value={moment(this.props.auctionDate).isValid() ?  moment(this.props.auctionDate).format('YYYY-MM-DDTHH:mm') : moment().add(1, 'days').format('YYYY-MM-DDTHH:mm')}
             onChange={this.props.handleChange} />
         </div>
         <div id='auctionItemExpiryDiv'>

--- a/src/components/createGame.js
+++ b/src/components/createGame.js
@@ -17,7 +17,7 @@ class CreateGame extends Component {
       auctionDollars: 100,
       startDate: '',
       endDate: '',
-      auctionDate: moment().add(7, 'days').format('YYYY-MM-DDTHH:mm'),
+      auctionDate: '',
       auctionItemExpiryTimeSeconds: 30,
       movies: [],
       playWithRules: false,


### PR DESCRIPTION
The old default could have had the default auction date set after the start date which was a bit messy.