### PR TITLE
Open new connection for each auction item

### DIFF
--- a/src/components/auctionHome.js
+++ b/src/components/auctionHome.js
@@ -13,7 +13,6 @@ class AuctionHome extends Component {
     this.state = {
       auctionDurationLoaded: false,
       currentUser: '',
-      webSocket: null,
       auctionCountdownIntervalId: '',
       auctionDuration: null,
       players: [],
@@ -27,8 +26,6 @@ class AuctionHome extends Component {
     this.renderAuctionPage = this.renderAuctionPage.bind(this)
     this.renderAuctionEndButton = this.renderAuctionEndButton.bind(this)
   }
-
-  webSocket = new WebSocket(process.env.REACT_APP_WEBSOCKET_URL)
 
   componentDidMount() {
     this.fetchCurrentUser()
@@ -45,10 +42,6 @@ class AuctionHome extends Component {
     this.setState({auctionCountdownIntervalId: intervalId})
     this.setState({auctionDurationLoaded: true})
     this._isMounted = true
-
-    this.webSocket.onclose = () => {
-      this.webSocket = new WebSocket(process.env.REACT_APP_WEBSOCKET_URL)
-    }
   }
 
   componentWillUnmount() {
@@ -163,7 +156,6 @@ class AuctionHome extends Component {
         movie={movie}
         gameId={this.props.gameId}
         auctionItemsExpireInSeconds={this.props.auctionItemsExpireInSeconds}
-        webSocket={this.webSocket}
         fetchPlayers={this.fetchPlayers}
         handleError={this.handleError}/>
     })

--- a/src/components/auctionItem.js
+++ b/src/components/auctionItem.js
@@ -28,6 +28,8 @@ class AuctionItem extends Component {
       uuid: this.props.gameId + this.props.gameId
     });
 
+    this.webSocket = new WebSocket(process.env.REACT_APP_WEBSOCKET_URL)
+
     this.callbackFunction = this.callbackFunction.bind(this)
     this.joinAuction = this.joinAuction.bind(this)
     this.updateBid = this.updateBid.bind(this)
@@ -48,8 +50,12 @@ class AuctionItem extends Component {
 	}
 
   componentDidMount() {
-    this.props.webSocket.onopen = () => {
+    this.webSocket.onopen = () => {
       this.setState({connectedToWebSocket: true})
+    }
+
+    this.webSocket.onclose = () => {
+      this.webSocket = new WebSocket(process.env.REACT_APP_WEBSOCKET_URL)
     }
   }
 
@@ -59,7 +65,7 @@ class AuctionItem extends Component {
         'message': 'leaveauction',
         'auctionID': this.state.auctionID
       }
-      this.props.webSocket.send(JSON.stringify(message))
+      this.webSocket.send(JSON.stringify(message))
     }
   }
 
@@ -68,12 +74,12 @@ class AuctionItem extends Component {
       'message': 'joinauction',
       'auctionID': this.state.auctionID
     }
-    this.props.webSocket.send(JSON.stringify(message))
+    this.webSocket.send(JSON.stringify(message))
 
-    this.props.webSocket.onmessage = (event) => {
+    this.webSocket.onmessage = (event) => {
       let eventData = JSON.parse(event.data)
-
-      if(eventData.message.hasOwnProperty('auctionExpiry')) {
+      console.log(eventData.message)
+      if(eventData.message.hasOwnProperty('auctionID') && eventData.message.auctionID === this.state.auctionID) {
         this.updateHighBid(eventData.message)
       }
     }
@@ -171,7 +177,7 @@ class AuctionItem extends Component {
               'userHandle': data.userHandle,
               'auctionExpiry': data.auctionExpiry
             }
-            this.props.webSocket.send(JSON.stringify(message))
+            this.webSocket.send(JSON.stringify(message))
           }
         }
       })

--- a/src/components/auctionItem.js
+++ b/src/components/auctionItem.js
@@ -78,7 +78,7 @@ class AuctionItem extends Component {
 
     this.webSocket.onmessage = (event) => {
       let eventData = JSON.parse(event.data)
-      console.log(eventData.message)
+      
       if(eventData.message.hasOwnProperty('auctionID') && eventData.message.auctionID === this.state.auctionID) {
         this.updateHighBid(eventData.message)
       }


### PR DESCRIPTION
The reason for this is because multiple auction items being auctioned at the same time was an issue. If auction item A and B were being auctioned at the same time, bidding on A, then B, then A again would update B, not A.

With independent connections for each auction item, this isn't happening anymore.