### PR TITLE
Fix item render when auction is over

### DIFF
--- a/src/components/auctionItem.js
+++ b/src/components/auctionItem.js
@@ -35,8 +35,8 @@ class AuctionItem extends Component {
   componentDidUpdate(prevProps) {
     if (prevProps.auctionExpiry !== this.props.auctionExpiry) {
       this.setState({auctionStarted: this.props.auctionStarted})
-      this.setState({auctionExpiry: this.props.auctionExpiry})
       this.setState({currentTime: this.props.currentTime})
+      this.setState({auctionExpiry: this.props.auctionExpiry})
       this.setState({currentHighBid: this.props.bid})
       this.setState({highestBidder: this.props.userHandle})
       this.setState({bid: parseInt(this.props.bid, 10) + 1})

--- a/src/components/auctionItem.js
+++ b/src/components/auctionItem.js
@@ -35,8 +35,8 @@ class AuctionItem extends Component {
   componentDidUpdate(prevProps) {
     if (prevProps.auctionExpiry !== this.props.auctionExpiry) {
       this.setState({auctionStarted: this.props.auctionStarted})
-      this.setState({currentTime: this.props.currentTime})
       this.setState({auctionExpiry: this.props.auctionExpiry})
+      this.setState({currentTime: this.props.currentTime})
       this.setState({currentHighBid: this.props.bid})
       this.setState({highestBidder: this.props.userHandle})
       this.setState({bid: parseInt(this.props.bid, 10) + 1})
@@ -169,7 +169,7 @@ class AuctionItem extends Component {
   }
 
   renderAuctionItem() {
-    if (this.state.auctionExpirySet &&
+    if ((this.props.auctionExpirySet || this.state.auctionExpirySet) &&
       (this.state.currentHighBid >= this.state.dollarSpendingCap ||
       moment(this.state.currentTime) >= moment(this.state.auctionExpiry))) {
 


### PR DESCRIPTION
For other clients, the current state of auctionExpirySet could stay false, evaluate props as well to make sure item renders properly when timer hits 0.